### PR TITLE
Adopt width to min-width and changed height to auto to fit the width

### DIFF
--- a/brands.css
+++ b/brands.css
@@ -61,8 +61,8 @@
   margin-bottom: 10px;
   padding: 10px; /* 17px */
   text-decoration: none;
-  width: 500px;
-  height: 48;
+  min-width: 320px;
+  height: auto;
   /* transition: all .25s cubic-bezier(.08, .59, .29, .99); */
   -webkit-tap-highlight-color: transparent;
 }


### PR DESCRIPTION
The design of the buttons are not mobile friendly at the moment.

To make it suitable for smartphones I adopt the brands.css file and changed the lines:

width: 500px;
height 48;

to

min-width: 320px; (looks fine on google pixel 7 and IPhone SE)
height: auto; (To grow with the width and the text automatically)